### PR TITLE
Utilized lombok Value

### DIFF
--- a/civitas.base/src/main/java/civitas/crypto/ciphertext/ElGamalCiphertext.java
+++ b/civitas.base/src/main/java/civitas/crypto/ciphertext/ElGamalCiphertext.java
@@ -7,12 +7,10 @@
 package civitas.crypto.ciphertext;
 
 import civitas.util.CivitasBigInteger;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
-@AllArgsConstructor
+@Value
 public class ElGamalCiphertext implements ElGamalCiphertextish {
 	@NonNull public CivitasBigInteger a;
 

--- a/civitas.base/src/main/java/civitas/crypto/parameters/ElGamalParameters.java
+++ b/civitas.base/src/main/java/civitas/crypto/parameters/ElGamalParameters.java
@@ -7,15 +7,10 @@
 package civitas.crypto.parameters;
 
 import civitas.util.CivitasBigInteger;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Value;
 
 @Value
-@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
-@AllArgsConstructor
 public class ElGamalParameters {
 
 	@NonNull public CivitasBigInteger p;

--- a/civitas.base/src/main/java/civitas/crypto/parameters/ElGamalParameters.java
+++ b/civitas.base/src/main/java/civitas/crypto/parameters/ElGamalParameters.java
@@ -9,18 +9,18 @@ package civitas.crypto.parameters;
 import civitas.util.CivitasBigInteger;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
+@Value
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class ElGamalParameters {
 
-	@NonNull public final CivitasBigInteger p;
+	@NonNull public CivitasBigInteger p;
 
-	@NonNull public final CivitasBigInteger q;
+	@NonNull public CivitasBigInteger q;
 
-	@NonNull public final CivitasBigInteger g;
+	@NonNull public CivitasBigInteger g;
 }

--- a/civitas.base/src/main/java/civitas/crypto/publickey/ElGamalPublicKey.java
+++ b/civitas.base/src/main/java/civitas/crypto/publickey/ElGamalPublicKey.java
@@ -10,16 +10,16 @@ import civitas.crypto.parameters.ElGamalParameters;
 import civitas.util.CivitasBigInteger;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
+@Value
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class ElGamalPublicKey {
 
-	@NonNull public final CivitasBigInteger y;
+	@NonNull public CivitasBigInteger y;
 
-	@NonNull public final ElGamalParameters params;
+	@NonNull public ElGamalParameters params;
 }

--- a/civitas.base/src/main/java/civitas/crypto/signedciphertext/ElGamalSignedCiphertext.java
+++ b/civitas.base/src/main/java/civitas/crypto/signedciphertext/ElGamalSignedCiphertext.java
@@ -8,16 +8,16 @@ package civitas.crypto.signedciphertext;
 
 import civitas.crypto.ciphertext.ElGamalCiphertextish;
 import civitas.util.CivitasBigInteger;
-import lombok.Data;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
+@Value
 public class ElGamalSignedCiphertext implements ElGamalCiphertextish {
 	@NonNull public CivitasBigInteger a;
 
 	@NonNull public CivitasBigInteger b;
 
-	@NonNull public final CivitasBigInteger c;
+	@NonNull public CivitasBigInteger c;
 
-	@NonNull public final CivitasBigInteger d;
+	@NonNull public CivitasBigInteger d;
 }

--- a/civitas.common/src/main/java/civitas/bboard/server/controllers/PostController.java
+++ b/civitas.common/src/main/java/civitas/bboard/server/controllers/PostController.java
@@ -82,10 +82,11 @@ public class PostController {
 	@ResponseBody
 	public Long apply(@PathVariable("bbid") final String bbid, @RequestBody final PostDTO dto)
 			throws CommunicableException {
-		String objectID = dto.meta + bbid;
-		checkAccess.apply(Operation.POST, dto.signature.getSignerPubKey(), objectID);
+		String objectID = dto.meta() + bbid;
+		checkAccess.apply(Operation.POST, dto.signature().getSignerPubKey(), objectID);
 		try {
-			if (!verifyPublicKeySignature.apply(dto.signature, dto.payloadXml.getBytes())) {
+			if (!verifyPublicKeySignature.apply(
+					dto.signature(), dto.payloadXml().getBytes())) {
 				throw new CommunicableException("bad signature");
 			}
 		} catch (CryptoException e) {
@@ -106,10 +107,10 @@ public class PostController {
 			lastPost = lastPosts.iterator().next();
 			hash = lastPost.hash;
 		}
-		byte[] newhash = cryptoHash.apply(hash, BigInteger.valueOf(t).toByteArray(), dto.signature.signatureBytes);
+		byte[] newhash = cryptoHash.apply(hash, BigInteger.valueOf(t).toByteArray(), dto.signature().signatureBytes);
 
 		try {
-			updateCache.apply(bbid, dto.meta, dto.payloadXml, t);
+			updateCache.apply(bbid, dto.meta(), dto.payloadXml(), t);
 		} catch (IOException | JAXBException e) {
 			throw new CommunicableException("bad payload xml");
 		}
@@ -118,7 +119,7 @@ public class PostController {
 		if (lastPost != null) {
 			serial = lastPost.serial;
 		}
-		bBPostRepository.save(new BBPost(bbid, serial + 1, t, dto.meta, dto.payloadXml, dto.signature, newhash));
+		bBPostRepository.save(new BBPost(bbid, serial + 1, t, dto.meta(), dto.payloadXml(), dto.signature(), newhash));
 
 		return t;
 	}

--- a/civitas.common/src/main/java/civitas/bboard/server/controllers/RequestParticipationController.java
+++ b/civitas.common/src/main/java/civitas/bboard/server/controllers/RequestParticipationController.java
@@ -52,29 +52,29 @@ public class RequestParticipationController implements CommonConstants {
 			throws UnrecoverableKeyException, InvalidKeyException, KeyStoreException, NoSuchAlgorithmException,
 					CertificateException, NoSuchProviderException, SignatureException, JAXBException, IOException,
 					CommunicableException, InvalidKeySpecException, CryptoException {
-		if (participationRequest == null || participationRequest.electionID == null) {
+		if (participationRequest == null || participationRequest.electionID() == null) {
 			return null;
 		}
 		ElectionDetails electionDetails = new ElectionDetails(
-				participationRequest.electionID,
-				participationRequest.supervisorPubkey,
-				participationRequest.registrarPubKey,
-				participationRequest.name,
-				participationRequest.description,
-				participationRequest.version,
-				participationRequest.ballotDesign,
-				participationRequest.startTime,
-				participationRequest.stopTime,
-				participationRequest.finalizeTime,
-				participationRequest.elGamalP,
-				participationRequest.elGamalQ,
-				participationRequest.elGamalG,
-				participationRequest.sharedKeyLength,
-				participationRequest.nonceLength,
-				participationRequest.voterAnonymityParam);
-		PublicKey supervisorPubKey = convertStringToPublicKey.apply(participationRequest.supervisorPubkey);
+				participationRequest.electionID(),
+				participationRequest.supervisorPubkey(),
+				participationRequest.registrarPubKey(),
+				participationRequest.name(),
+				participationRequest.description(),
+				participationRequest.version(),
+				participationRequest.ballotDesign(),
+				participationRequest.startTime(),
+				participationRequest.stopTime(),
+				participationRequest.finalizeTime(),
+				participationRequest.elGamalP(),
+				participationRequest.elGamalQ(),
+				participationRequest.elGamalG(),
+				participationRequest.sharedKeyLength(),
+				participationRequest.nonceLength(),
+				participationRequest.voterAnonymityParam());
+		PublicKey supervisorPubKey = convertStringToPublicKey.apply(participationRequest.supervisorPubkey());
 		String boardId = newBoardController.apply(supervisorPubKey);
-		int myIndex = participationRequest.tellerDetails.stream()
+		int myIndex = participationRequest.tellerDetails().stream()
 				.map(host -> ServerRole.BBS.equals(host.getRole())
 						&& host.getUrlbase().equals(configuration.urlBase))
 				.toList()

--- a/civitas.common/src/main/java/civitas/bboard/server/electioncache/UpdateCache.java
+++ b/civitas.common/src/main/java/civitas/bboard/server/electioncache/UpdateCache.java
@@ -32,12 +32,12 @@ public class UpdateCache {
 
 		if (CommonConstants.ElectionEventMETA.equals(meta)) {
 			ElectionEvent e = convertFromXml.apply(mesg, ElectionEvent.class);
-			if (ElectionEvent.EVENT_KIND_FINALIZE.equals(e.getKind())) {
+			if (ElectionEvent.EVENT_KIND_FINALIZE.equals(e.kind())) {
 				// FIXME: tally
 				cache.electionFinalizeTime = t;
-			} else if (ElectionEvent.EVENT_KIND_START.equals(e.getKind())) {
+			} else if (ElectionEvent.EVENT_KIND_START.equals(e.kind())) {
 				cache.electionStartTime = t;
-			} else if (ElectionEvent.EVENT_KIND_STOP.equals(e.getKind())) {
+			} else if (ElectionEvent.EVENT_KIND_STOP.equals(e.kind())) {
 				cache.electionStopTime = t;
 			}
 		}

--- a/civitas.common/src/main/java/civitas/common/board/GetContentCommitmentForBoard.java
+++ b/civitas.common/src/main/java/civitas/common/board/GetContentCommitmentForBoard.java
@@ -3,7 +3,7 @@ package civitas.common.board;
 public class GetContentCommitmentForBoard {
 	public BoardClosedContentCommitment apply(final BoardsForTabulation that, final String boardName) {
 		for (BoardClosedContentCommitment cc : that.contentComs) {
-			if (cc.boardName.equals(boardName)) {
+			if (cc.boardName().equals(boardName)) {
 				return cc;
 			}
 		}

--- a/civitas.crypto/src/main/java/civitas/bboard/common/BBPost.java
+++ b/civitas.crypto/src/main/java/civitas/bboard/common/BBPost.java
@@ -10,24 +10,24 @@ import org.springframework.data.annotation.Id;
 
 import civitas.crypto.signature.Signature;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import lombok.Data;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
+@Value
 @XmlRootElement(name = "bbpost")
-public final class BBPost {
+public class BBPost {
 	@NonNull @Id
-	public final String bbid;
+	public String bbid;
 
-	@NonNull public final Long serial;
+	@NonNull public Long serial;
 
-	@NonNull public final Long timestamp;
+	@NonNull public Long timestamp;
 
-	@NonNull public final String meta;
+	@NonNull public String meta;
 
-	@NonNull public final String msg;
+	@NonNull public String msg;
 
-	@NonNull public final Signature sig;
+	@NonNull public Signature sig;
 
-	@NonNull public final byte[] hash;
+	@NonNull public byte[] hash;
 }

--- a/civitas.crypto/src/main/java/civitas/bboard/common/BBPost.java
+++ b/civitas.crypto/src/main/java/civitas/bboard/common/BBPost.java
@@ -29,5 +29,5 @@ public class BBPost {
 
 	@NonNull public Signature sig;
 
-	@NonNull public byte[] hash;
+	public byte @NonNull [] hash;
 }

--- a/civitas.crypto/src/main/java/civitas/bboard/server/controllers/PostDTO.java
+++ b/civitas.crypto/src/main/java/civitas/bboard/server/controllers/PostDTO.java
@@ -1,15 +1,5 @@
 package civitas.bboard.server.controllers;
 
 import civitas.crypto.signature.Signature;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class PostDTO {
-	public String meta;
-	public String payloadXml;
-	public Signature signature;
-}
+public record PostDTO(String meta, String payloadXml, Signature signature) {}

--- a/civitas.crypto/src/main/java/civitas/bboard/server/controllers/RequestParticipationDTO.java
+++ b/civitas.crypto/src/main/java/civitas/bboard/server/controllers/RequestParticipationDTO.java
@@ -5,48 +5,25 @@ import java.util.List;
 
 import civitas.common.ServerHost;
 import civitas.common.ballotdesign.BallotDesign;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
-@Data
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public class RequestParticipationDTO {
-	@NonNull public String electionID;
-
-	@NonNull public String supervisorPubkey;
-
-	@NonNull public String registrarPubKey;
-
-	@NonNull public String name;
-
-	@NonNull public String description;
-
-	@NonNull public String version;
-
-	@NonNull public BallotDesign ballotDesign;
-
-	@NonNull public String startTime;
-
-	@NonNull public String stopTime;
-
-	@NonNull public String finalizeTime;
-
-	@NonNull public BigInteger elGamalP;
-
-	@NonNull public BigInteger elGamalQ;
-
-	@NonNull public BigInteger elGamalG;
-
-	@NonNull public Integer sharedKeyLength;
-
-	@NonNull public Integer nonceLength;
-
-	@NonNull public Integer voterAnonymityParam;
-
-	@NonNull List<ServerHost> tellerDetails;
-}
+public record RequestParticipationDTO(
+		@NonNull String electionID,
+		@NonNull String supervisorPubkey,
+		@NonNull String registrarPubKey,
+		@NonNull String name,
+		@NonNull String description,
+		@NonNull String version,
+		@NonNull BallotDesign ballotDesign,
+		@NonNull String startTime,
+		@NonNull String stopTime,
+		@NonNull String finalizeTime,
+		@NonNull BigInteger elGamalP,
+		@NonNull BigInteger elGamalQ,
+		@NonNull BigInteger elGamalG,
+		@NonNull Integer sharedKeyLength,
+		@NonNull Integer nonceLength,
+		@NonNull Integer voterAnonymityParam,
+		@NonNull List<ServerHost> tellerDetails) {}

--- a/civitas.crypto/src/main/java/civitas/common/VoterEncCapabilityShares.java
+++ b/civitas.crypto/src/main/java/civitas/common/VoterEncCapabilityShares.java
@@ -7,12 +7,12 @@
 package civitas.common;
 
 import civitas.crypto.signedciphertext.ElGamalSignedCiphertext;
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 public class VoterEncCapabilityShares {
-	public final int regTellerIndex;
-	public final String name;
-	public final int voterBlock;
-	public final ElGamalSignedCiphertext[] encCapabilityShares;
+	public int regTellerIndex;
+	public String name;
+	public int voterBlock;
+	public ElGamalSignedCiphertext[] encCapabilityShares;
 }

--- a/civitas.crypto/src/main/java/civitas/common/ballot/Ballot.java
+++ b/civitas.crypto/src/main/java/civitas/common/ballot/Ballot.java
@@ -8,12 +8,12 @@ package civitas.common.ballot;
 
 import civitas.common.CommonConstants;
 import civitas.common.VoteChoice;
-import lombok.Data;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
+@Value
 public class Ballot implements CommonConstants {
-	@NonNull public final Integer k;
+	@NonNull public Integer k;
 
-	@NonNull public final VoteChoice[] matrix;
+	@NonNull public VoteChoice[] matrix;
 }

--- a/civitas.crypto/src/main/java/civitas/common/board/BoardClosedContentCommitment.java
+++ b/civitas.crypto/src/main/java/civitas/common/board/BoardClosedContentCommitment.java
@@ -14,15 +14,8 @@ import civitas.common.CommonConstants;
 import civitas.common.election.ElectionID;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import lombok.NonNull;
-import lombok.Value;
 
-@Value
 @XmlRootElement(name = "boardclosedcontentcommitment")
-public class BoardClosedContentCommitment implements CommonConstants {
-	@Id
-	@NonNull public ElectionID electionID;
-
-	@NonNull public String boardName;
-
-	@NonNull public List<String> voterBlockContentHash;
-}
+public record BoardClosedContentCommitment(
+		@Id @NonNull ElectionID electionID, @NonNull String boardName, @NonNull List<String> voterBlockContentHash)
+		implements CommonConstants {}

--- a/civitas.crypto/src/main/java/civitas/common/board/BoardClosedContentCommitment.java
+++ b/civitas.crypto/src/main/java/civitas/common/board/BoardClosedContentCommitment.java
@@ -13,20 +13,16 @@ import org.springframework.data.annotation.Id;
 import civitas.common.CommonConstants;
 import civitas.common.election.ElectionID;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
+@Value
 @XmlRootElement(name = "boardclosedcontentcommitment")
-@NoArgsConstructor
-@AllArgsConstructor
 public class BoardClosedContentCommitment implements CommonConstants {
 	@Id
-	@NonNull ElectionID electionID;
+	@NonNull public ElectionID electionID;
 
-	@NonNull String boardName;
+	@NonNull public String boardName;
 
-	@NonNull List<String> voterBlockContentHash;
+	@NonNull public List<String> voterBlockContentHash;
 }

--- a/civitas.crypto/src/main/java/civitas/common/board/BoardsForTabulation.java
+++ b/civitas.crypto/src/main/java/civitas/common/board/BoardsForTabulation.java
@@ -7,9 +7,9 @@
 package civitas.common.board;
 
 import io.micrometer.common.lang.NonNull;
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 public class BoardsForTabulation {
-	@NonNull public final BoardClosedContentCommitment[] contentComs;
+	@NonNull public BoardClosedContentCommitment[] contentComs;
 }

--- a/civitas.crypto/src/main/java/civitas/common/capabilityencryption/VoterEncCapabilities.java
+++ b/civitas.crypto/src/main/java/civitas/common/capabilityencryption/VoterEncCapabilities.java
@@ -7,11 +7,11 @@
 package civitas.common.capabilityencryption;
 
 import civitas.crypto.ciphertext.ElGamalCiphertext;
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 public class VoterEncCapabilities {
-	public final String name;
-	public final int voterBlock;
-	public final ElGamalCiphertext[] encCapabilities;
+	public String name;
+	public int voterBlock;
+	public ElGamalCiphertext[] encCapabilities;
 }

--- a/civitas.crypto/src/main/java/civitas/common/election/ElectionEvent.java
+++ b/civitas.crypto/src/main/java/civitas/common/election/ElectionEvent.java
@@ -11,9 +11,9 @@ public interface ElectionEvent {
 	String EVENT_KIND_STOP = "stop";
 	String EVENT_KIND_FINALIZE = "finalize";
 
-	String getKind();
+	String kind();
 
-	ElectionID getElectionID();
+	ElectionID electionID();
 
-	int getSequence();
+	int sequence();
 }

--- a/civitas.crypto/src/main/java/civitas/common/election/ElectionEventFinalize.java
+++ b/civitas.crypto/src/main/java/civitas/common/election/ElectionEventFinalize.java
@@ -7,13 +7,12 @@
 package civitas.common.election;
 
 import civitas.common.tallystatefinal.TallyStateFinal;
-import lombok.Value;
 
-@Value
-public class ElectionEventFinalize implements ElectionEvent {
-	public String kind = EVENT_KIND_FINALIZE;
-	public ElectionID electionID;
-	public int sequence;
-	public TallyStateFinal tally;
-	public String message;
+public record ElectionEventFinalize(ElectionID electionID, int sequence, TallyStateFinal tally, String message)
+		implements ElectionEvent {
+
+	@Override
+	public String kind() {
+		return EVENT_KIND_FINALIZE;
+	}
 }

--- a/civitas.crypto/src/main/java/civitas/common/election/ElectionEventFinalize.java
+++ b/civitas.crypto/src/main/java/civitas/common/election/ElectionEventFinalize.java
@@ -7,13 +7,13 @@
 package civitas.common.election;
 
 import civitas.common.tallystatefinal.TallyStateFinal;
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 public class ElectionEventFinalize implements ElectionEvent {
-	public final String kind = EVENT_KIND_FINALIZE;
-	public final ElectionID electionID;
-	public final int sequence;
-	public final TallyStateFinal tally;
-	public final String message;
+	public String kind = EVENT_KIND_FINALIZE;
+	public ElectionID electionID;
+	public int sequence;
+	public TallyStateFinal tally;
+	public String message;
 }

--- a/civitas.crypto/src/main/java/civitas/common/electoralroll/ElectoralRoll.java
+++ b/civitas.crypto/src/main/java/civitas/common/electoralroll/ElectoralRoll.java
@@ -7,11 +7,11 @@
 package civitas.common.electoralroll;
 
 import civitas.common.VoterDetails;
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 public class ElectoralRoll {
 	public static final String META = "electoralRoll";
 
-	public final VoterDetails[] roll;
+	public VoterDetails[] roll;
 }

--- a/civitas.crypto/src/main/java/civitas/common/electoralroll/ElectoralRollCapabilities.java
+++ b/civitas.crypto/src/main/java/civitas/common/electoralroll/ElectoralRollCapabilities.java
@@ -7,9 +7,9 @@
 package civitas.common.electoralroll;
 
 import civitas.common.capabilityencryption.VoterEncCapabilities;
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 public class ElectoralRollCapabilities {
-	public final VoterEncCapabilities[] roll;
+	public VoterEncCapabilities[] roll;
 }

--- a/civitas.crypto/src/main/java/civitas/common/electoralroll/ElectoralRollCapabilityShares.java
+++ b/civitas.crypto/src/main/java/civitas/common/electoralroll/ElectoralRollCapabilityShares.java
@@ -7,11 +7,11 @@
 package civitas.common.electoralroll;
 
 import civitas.common.VoterEncCapabilityShares;
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 public class ElectoralRollCapabilityShares {
-	public final VoterEncCapabilityShares[] roll;
-	public final int tellerIndex;
-	public final int voterBlock;
+	public VoterEncCapabilityShares[] roll;
+	public int tellerIndex;
+	public int voterBlock;
 }

--- a/civitas.crypto/src/main/java/civitas/common/mix/capabilityelementrevelation/MixCapabilityElementRevelation.java
+++ b/civitas.crypto/src/main/java/civitas/common/mix/capabilityelementrevelation/MixCapabilityElementRevelation.java
@@ -8,11 +8,11 @@ package civitas.common.mix.capabilityelementrevelation;
 
 import civitas.common.mix.elementrevelation.MixElementRevelation;
 import civitas.crypto.reencryptfactor.ElGamalReencryptFactor;
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 public class MixCapabilityElementRevelation implements MixElementRevelation {
-	final int mapping;
-	final byte[] nonce;
-	public final ElGamalReencryptFactor reencryptFactor;
+	int mapping;
+	byte[] nonce;
+	public ElGamalReencryptFactor reencryptFactor;
 }

--- a/civitas.crypto/src/main/java/civitas/common/mix/capabilitymix/CapabilityMix.java
+++ b/civitas.crypto/src/main/java/civitas/common/mix/capabilitymix/CapabilityMix.java
@@ -15,7 +15,7 @@ import lombok.NonNull;
 public class CapabilityMix implements VoterMix {
 	@NonNull public final Integer number;
 
-	@NonNull public final byte[] mixNonceHash;
+	public final byte @NonNull [] mixNonceHash;
 
 	@NonNull public byte[][] commitments;
 

--- a/civitas.crypto/src/main/java/civitas/common/mix/hashrevelation/MixHashRevelation.java
+++ b/civitas.crypto/src/main/java/civitas/common/mix/hashrevelation/MixHashRevelation.java
@@ -6,12 +6,12 @@
  */
 package civitas.common.mix.hashrevelation;
 
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 public class MixHashRevelation {
 
-	public final int tellerIndex;
+	public int tellerIndex;
 
-	public final byte[] mixNonce;
+	public byte[] mixNonce;
 }

--- a/civitas.crypto/src/main/java/civitas/common/mix/revelation/MixRevelation.java
+++ b/civitas.crypto/src/main/java/civitas/common/mix/revelation/MixRevelation.java
@@ -7,14 +7,14 @@
 package civitas.common.mix.revelation;
 
 import civitas.common.mix.elementrevelation.MixElementRevelation;
-import lombok.Data;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
+@Value
 public class MixRevelation {
-	public final int tellerIndex;
+	public int tellerIndex;
 
-	@NonNull public final boolean[] indicators;
+	@NonNull public boolean[] indicators;
 
-	@NonNull public final MixElementRevelation[] revelations;
+	@NonNull public MixElementRevelation[] revelations;
 }

--- a/civitas.crypto/src/main/java/civitas/common/mix/revelation/MixRevelation.java
+++ b/civitas.crypto/src/main/java/civitas/common/mix/revelation/MixRevelation.java
@@ -14,7 +14,7 @@ import lombok.Value;
 public class MixRevelation {
 	public int tellerIndex;
 
-	@NonNull public boolean[] indicators;
+	public boolean @NonNull [] indicators;
 
 	@NonNull public MixElementRevelation[] revelations;
 }

--- a/civitas.crypto/src/main/java/civitas/common/mix/voteelementrevelation/MixVoteElementRevelation.java
+++ b/civitas.crypto/src/main/java/civitas/common/mix/voteelementrevelation/MixVoteElementRevelation.java
@@ -8,13 +8,13 @@ package civitas.common.mix.voteelementrevelation;
 
 import civitas.common.mix.elementrevelation.MixElementRevelation;
 import civitas.crypto.reencryptfactor.ElGamalReencryptFactor;
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 public class MixVoteElementRevelation implements MixElementRevelation {
 
-	public final ElGamalReencryptFactor choiceFactor;
-	public final ElGamalReencryptFactor reencryptFactor;
-	public final int mapping;
-	public final byte[] nonce;
+	public ElGamalReencryptFactor choiceFactor;
+	public ElGamalReencryptFactor reencryptFactor;
+	public int mapping;
+	public byte[] nonce;
 }

--- a/civitas.crypto/src/main/java/civitas/common/mix/votemix/VoteMix.java
+++ b/civitas.crypto/src/main/java/civitas/common/mix/votemix/VoteMix.java
@@ -17,9 +17,9 @@ import lombok.NonNull;
 public class VoteMix implements VoterMix {
 	@NonNull public Integer number;
 
-	@NonNull public byte[] mixNonceHash;
+	public byte @NonNull [] mixNonceHash;
 
-	@NonNull public byte[][] commitments;
+	public byte[][] commitments;
 
 	@NonNull public EncryptedVote[] votes;
 

--- a/civitas.crypto/src/main/java/civitas/common/tabteller/distributeddecryptions/TabTellerDistributedDecryptions.java
+++ b/civitas.crypto/src/main/java/civitas/common/tabteller/distributeddecryptions/TabTellerDistributedDecryptions.java
@@ -8,14 +8,14 @@ package civitas.common.tabteller.distributeddecryptions;
 
 import civitas.crypto.decriptionshare.ElGamalDecryptionShare;
 import civitas.crypto.proofdisclog.ElGamalProofDiscLogEquality;
-import lombok.Data;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
+@Value
 public class TabTellerDistributedDecryptions {
-	public final int tellerIndex;
+	public int tellerIndex;
 
-	@NonNull public final ElGamalDecryptionShare[] decrypts;
+	@NonNull public ElGamalDecryptionShare[] decrypts;
 
-	@NonNull public final ElGamalProofDiscLogEquality[] proofs;
+	@NonNull public ElGamalProofDiscLogEquality[] proofs;
 }

--- a/civitas.crypto/src/main/java/civitas/common/tabteller/petcommitments/TabTellerPETShareCommitments.java
+++ b/civitas.crypto/src/main/java/civitas/common/tabteller/petcommitments/TabTellerPETShareCommitments.java
@@ -7,10 +7,10 @@
 package civitas.common.tabteller.petcommitments;
 
 import civitas.crypto.petcommitment.PETCommitment;
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 public class TabTellerPETShareCommitments {
-	public final int tellerIndex;
-	public final PETCommitment[] commitments;
+	public int tellerIndex;
+	public PETCommitment[] commitments;
 }

--- a/civitas.crypto/src/main/java/civitas/common/tabteller/petsharedecommitments/TabTellerPETShareDecommitments.java
+++ b/civitas.crypto/src/main/java/civitas/common/tabteller/petsharedecommitments/TabTellerPETShareDecommitments.java
@@ -8,11 +8,11 @@ package civitas.common.tabteller.petsharedecommitments;
 
 import civitas.crypto.petdecommitment.PETDecommitment;
 import civitas.crypto.proofdisclog.ElGamalProofDiscLogEquality;
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 public class TabTellerPETShareDecommitments {
-	public final int tellerIndex;
-	public final PETDecommitment[] decommitments;
-	public final ElGamalProofDiscLogEquality[] proofs;
+	public int tellerIndex;
+	public PETDecommitment[] decommitments;
+	public ElGamalProofDiscLogEquality[] proofs;
 }

--- a/civitas.crypto/src/main/java/civitas/common/tallystate/TallyState.java
+++ b/civitas.crypto/src/main/java/civitas/common/tallystate/TallyState.java
@@ -6,12 +6,12 @@
  */
 package civitas.common.tallystate;
 
-import lombok.Data;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
+@Value
 public class TallyState {
-	@NonNull public final Integer size;
+	@NonNull public Integer size;
 
-	@NonNull public final Integer[][] matrix;
+	@NonNull public Integer[][] matrix;
 }

--- a/civitas.crypto/src/main/java/civitas/common/tallystatefinal/TallyStateFinal.java
+++ b/civitas.crypto/src/main/java/civitas/common/tallystatefinal/TallyStateFinal.java
@@ -7,10 +7,10 @@
 package civitas.common.tallystatefinal;
 
 import civitas.common.CommonConstants;
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 public class TallyStateFinal implements CommonConstants {
-	private final Integer size;
-	private final Integer[][] matrix;
+	Integer size;
+	Integer[][] matrix;
 }

--- a/civitas.crypto/src/main/java/civitas/common/voterapabilityshares/VoterCapabilityShares.java
+++ b/civitas.crypto/src/main/java/civitas/common/voterapabilityshares/VoterCapabilityShares.java
@@ -7,10 +7,10 @@
 package civitas.common.voterapabilityshares;
 
 import civitas.crypto.votecapabilityshare.VoteCapabilityShare;
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 public class VoterCapabilityShares {
-	public final VoteCapabilityShare[] capabilities;
-	public final int voterBlock;
+	public VoteCapabilityShare[] capabilities;
+	public int voterBlock;
 }

--- a/civitas.crypto/src/main/java/civitas/common/votercapabilities/VoterCapabilities.java
+++ b/civitas.crypto/src/main/java/civitas/common/votercapabilities/VoterCapabilities.java
@@ -7,10 +7,10 @@
 package civitas.common.votercapabilities;
 
 import civitas.crypto.votecapability.VoteCapability;
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 public class VoterCapabilities {
-	public final VoteCapability[] capabilities;
-	public final int voterBlock;
+	public VoteCapability[] capabilities;
+	public int voterBlock;
 }

--- a/civitas.crypto/src/main/java/civitas/common/votercapabilitysharesandproofs/VoterCapabilitySharesAndProof.java
+++ b/civitas.crypto/src/main/java/civitas/common/votercapabilitysharesandproofs/VoterCapabilitySharesAndProof.java
@@ -9,16 +9,16 @@ package civitas.common.votercapabilitysharesandproofs;
 import civitas.crypto.proofdvr.ElGamalProofDVR;
 import civitas.crypto.reencryptfactor.ElGamalReencryptFactor;
 import civitas.crypto.votecapabilityshare.VoteCapabilityShare;
-import lombok.Data;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
+@Value
 public class VoterCapabilitySharesAndProof {
-	@NonNull public final VoteCapabilityShare[] capabilities;
+	@NonNull public VoteCapabilityShare[] capabilities;
 
-	@NonNull public final ElGamalReencryptFactor[] rencryptFactors;
+	@NonNull public ElGamalReencryptFactor[] rencryptFactors;
 
-	@NonNull public final ElGamalProofDVR[] proofs;
+	@NonNull public ElGamalProofDVR[] proofs;
 
-	public final int voterBlock;
+	public int voterBlock;
 }

--- a/civitas.crypto/src/main/java/civitas/common/votersubmission/VoterSubmission.java
+++ b/civitas.crypto/src/main/java/civitas/common/votersubmission/VoterSubmission.java
@@ -7,12 +7,12 @@
 package civitas.common.votersubmission;
 
 import civitas.common.verifiablevote.VerifiableVote;
-import lombok.Data;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
+@Value
 public class VoterSubmission {
-	@NonNull public final Integer voterBlock;
+	@NonNull public Integer voterBlock;
 
-	@NonNull public final VerifiableVote[] votes;
+	@NonNull public VerifiableVote[] votes;
 }

--- a/civitas.crypto/src/main/java/civitas/crypto/proof1ofl/ElGamalProof1OfL.java
+++ b/civitas.crypto/src/main/java/civitas/crypto/proof1ofl/ElGamalProof1OfL.java
@@ -7,12 +7,12 @@
 package civitas.crypto.proof1ofl;
 
 import civitas.util.CivitasBigInteger;
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 public class ElGamalProof1OfL {
 
-	public final int L;
-	public final CivitasBigInteger[] dvs;
-	public final CivitasBigInteger[] rvs;
+	public int L;
+	public CivitasBigInteger[] dvs;
+	public CivitasBigInteger[] rvs;
 }

--- a/civitas.crypto/src/main/java/civitas/crypto/proofvote/ProofVote.java
+++ b/civitas.crypto/src/main/java/civitas/crypto/proofvote/ProofVote.java
@@ -7,15 +7,15 @@
 package civitas.crypto.proofvote;
 
 import civitas.util.CivitasBigInteger;
-import lombok.Data;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
+@Value
 public class ProofVote {
 
-	@NonNull public final CivitasBigInteger c;
+	@NonNull public CivitasBigInteger c;
 
-	@NonNull public final CivitasBigInteger s1;
+	@NonNull public CivitasBigInteger s1;
 
-	@NonNull public final CivitasBigInteger s2;
+	@NonNull public CivitasBigInteger s2;
 }

--- a/civitas.crypto/src/main/java/civitas/crypto/publickeyciphertext/PublicKeyCiphertext.java
+++ b/civitas.crypto/src/main/java/civitas/crypto/publickeyciphertext/PublicKeyCiphertext.java
@@ -6,10 +6,10 @@
  */
 package civitas.crypto.publickeyciphertext;
 
-import lombok.Data;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
+@Value
 public class PublicKeyCiphertext {
-	@NonNull public final byte[] encryptedBytes;
+	@NonNull public byte[] encryptedBytes;
 }

--- a/civitas.crypto/src/main/java/civitas/crypto/publickeyciphertext/PublicKeyCiphertext.java
+++ b/civitas.crypto/src/main/java/civitas/crypto/publickeyciphertext/PublicKeyCiphertext.java
@@ -11,5 +11,5 @@ import lombok.Value;
 
 @Value
 public class PublicKeyCiphertext {
-	@NonNull public byte[] encryptedBytes;
+	public byte @NonNull [] encryptedBytes;
 }

--- a/civitas.crypto/src/main/java/civitas/crypto/sharedkeyciphertext/SharedKeyCiphertext.java
+++ b/civitas.crypto/src/main/java/civitas/crypto/sharedkeyciphertext/SharedKeyCiphertext.java
@@ -11,5 +11,5 @@ import lombok.Value;
 
 @Value
 public class SharedKeyCiphertext {
-	@NonNull public byte[] encryptedBytes;
+	public byte @NonNull [] encryptedBytes;
 }

--- a/civitas.crypto/src/main/java/civitas/crypto/sharedkeyciphertext/SharedKeyCiphertext.java
+++ b/civitas.crypto/src/main/java/civitas/crypto/sharedkeyciphertext/SharedKeyCiphertext.java
@@ -6,10 +6,10 @@
  */
 package civitas.crypto.sharedkeyciphertext;
 
-import lombok.Data;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
+@Value
 public class SharedKeyCiphertext {
-	@NonNull public final byte[] encryptedBytes;
+	@NonNull public byte[] encryptedBytes;
 }

--- a/civitas.crypto/src/main/java/civitas/crypto/signature/Signature.java
+++ b/civitas.crypto/src/main/java/civitas/crypto/signature/Signature.java
@@ -15,7 +15,7 @@ import lombok.NonNull;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Signature {
-	@NonNull public byte[] signatureBytes;
+	public byte @NonNull [] signatureBytes;
 
 	@NonNull String signerPubKey;
 }

--- a/civitas.crypto/src/main/java/civitas/result/Winners.java
+++ b/civitas.crypto/src/main/java/civitas/result/Winners.java
@@ -2,10 +2,10 @@ package civitas.result;
 
 import java.util.List;
 
-import lombok.Data;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
+@Value
 public class Winners {
 	@NonNull List<List<Integer>> result;
 


### PR DESCRIPTION
- Converted all `@Data` annotated classes without array members to records, where it did not break the tests.
- Replaced all `@Data` annotations with `@Value` where it did not break the tests.
- Moved `@NonNull` annotations on primitive 1D arrays to their proper place.